### PR TITLE
Feat/95 게시판 관련 이슈 처리

### DIFF
--- a/dplanner/lib/pages/my_activity_check_page.dart
+++ b/dplanner/lib/pages/my_activity_check_page.dart
@@ -22,7 +22,9 @@ class MyActivityCheckPage extends StatefulWidget {
 class _MyActivityCheckPageState extends State<MyActivityCheckPage> {
   List<Post> _myPosts = [];
   List<Comment> _postComments = [];
-  int _currentPage = 0;
+  List<Post> _likedPosts = [];
+  int _currentPage1 = 0;
+  int _currentPage2 = 0;
   bool _isLoading = false;
   ScrollController _scrollController = ScrollController();
 
@@ -32,6 +34,7 @@ class _MyActivityCheckPageState extends State<MyActivityCheckPage> {
     _scrollController.addListener(_scrollListener);
     _fetchMyPosts();
     _fetchMyComments(1043);
+    _fetchLikedPosts();
   }
 
   @override
@@ -57,10 +60,10 @@ class _MyActivityCheckPageState extends State<MyActivityCheckPage> {
     try {
       List<Post> newPosts = await PostApiService.fetchMyPosts(
           clubMemberID: MemberController.to.clubMember().id,
-          page: _currentPage);
+          page: _currentPage1);
       setState(() {
         _myPosts.addAll(newPosts);
-        _currentPage++;
+        _currentPage1++;
         _isLoading = false;
       });
     } catch (e) {
@@ -92,6 +95,28 @@ class _MyActivityCheckPageState extends State<MyActivityCheckPage> {
         _isLoading = false;
       });
       print('Error fetching comments: $e');
+    }
+  }
+
+  Future<void> _fetchLikedPosts() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      List<Post> likedPosts = await PostApiService.fetchLikedPosts(
+          clubMemberID: MemberController.to.clubMember().id,
+          page: _currentPage2);
+      setState(() {
+        _likedPosts.addAll(likedPosts);
+        _currentPage2++;
+      });
+    } catch (e) {
+      print('Error fetching posts: $e');
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
     }
   }
 
@@ -190,6 +215,31 @@ class _MyActivityCheckPageState extends State<MyActivityCheckPage> {
                     ),
           Container(
             color: AppColor.backgroundColor2,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(18, 24, 24, 24),
+              child: ListView.builder(
+                controller: _scrollController,
+                itemCount: _likedPosts.length + (_isLoading ? 1 : 0),
+                itemBuilder: (context, index) {
+                  if (index < _likedPosts.length) {
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 12.0),
+                      child: PostMiniCard(
+                        id: _likedPosts[index].id,
+                        title: _likedPosts[index].title ?? '제목 없음',
+                        content: _likedPosts[index].content,
+                        dateTime: _likedPosts[index].createdTime,
+                        isPhoto: _likedPosts[index].attachmentsUrl.isNotEmpty,
+                      ),
+                    );
+                  } else {
+                    return Center(
+                      child: CircularProgressIndicator(),
+                    );
+                  }
+                },
+              ),
+            ),
           ),
         ],
       ),

--- a/dplanner/lib/pages/my_activity_check_page.dart
+++ b/dplanner/lib/pages/my_activity_check_page.dart
@@ -151,6 +151,7 @@ class _MyActivityCheckPageState extends State<MyActivityCheckPage> {
                     return Padding(
                       padding: const EdgeInsets.only(bottom: 12.0),
                       child: PostMiniCard(
+                        id: _myPosts[index].id,
                         title: _myPosts[index].title ?? '제목 없음',
                         content: _myPosts[index].content,
                         dateTime: _myPosts[index].createdTime,

--- a/dplanner/lib/pages/my_activity_check_page.dart
+++ b/dplanner/lib/pages/my_activity_check_page.dart
@@ -1,5 +1,4 @@
 import 'package:contained_tab_bar_view/contained_tab_bar_view.dart';
-import 'package:dplanner/services/club_api_service.dart';
 import 'package:dplanner/services/club_post_api_service.dart';
 import 'package:dplanner/widgets/post_mini_card.dart';
 import 'package:flutter/material.dart';
@@ -154,7 +153,7 @@ class _MyActivityCheckPageState extends State<MyActivityCheckPage> {
                       child: PostMiniCard(
                         title: _myPosts[index].title ?? '제목 없음',
                         content: _myPosts[index].content,
-                        date: '${_myPosts[index].createdTime}',
+                        dateTime: _myPosts[index].createdTime,
                         isPhoto: _myPosts[index].attachmentsUrl.isNotEmpty,
                       ),
                     );

--- a/dplanner/lib/pages/my_activity_check_page.dart
+++ b/dplanner/lib/pages/my_activity_check_page.dart
@@ -1,124 +1,16 @@
 import 'package:contained_tab_bar_view/contained_tab_bar_view.dart';
 import 'package:dplanner/services/club_post_api_service.dart';
-import 'package:dplanner/widgets/post_mini_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_sfsymbols/flutter_sfsymbols.dart';
 import 'package:get/get.dart';
 
 import '../controllers/size.dart';
 import '../style.dart';
-import 'package:dplanner/models/post_model.dart';
-import 'package:dplanner/models/post_comment_model.dart';
-import 'package:dplanner/controllers/member.dart';
-import 'package:dplanner/widgets/comment_mini_card.dart';
 
-class MyActivityCheckPage extends StatefulWidget {
+import '../widgets/my_activity_posts.dart';
+
+class MyActivityCheckPage extends StatelessWidget {
   const MyActivityCheckPage({super.key});
-
-  @override
-  State<MyActivityCheckPage> createState() => _MyActivityCheckPageState();
-}
-
-class _MyActivityCheckPageState extends State<MyActivityCheckPage> {
-  List<Post> _myPosts = [];
-  List<Comment> _postComments = [];
-  List<Post> _likedPosts = [];
-  int _currentPage1 = 0;
-  int _currentPage2 = 0;
-  bool _isLoading = false;
-  ScrollController _scrollController = ScrollController();
-
-  @override
-  void initState() {
-    super.initState();
-    _scrollController.addListener(_scrollListener);
-    _fetchMyPosts();
-    _fetchMyComments(1043);
-    _fetchLikedPosts();
-  }
-
-  @override
-  void dispose() {
-    _scrollController.removeListener(_scrollListener);
-    _scrollController.dispose();
-    super.dispose();
-  }
-
-  void _scrollListener() {
-    if (!_isLoading &&
-        _scrollController.position.pixels ==
-            _scrollController.position.maxScrollExtent) {
-      _fetchMyPosts();
-    }
-  }
-
-  Future<void> _fetchMyPosts() async {
-    setState(() {
-      _isLoading = true;
-    });
-
-    try {
-      List<Post> newPosts = await PostApiService.fetchMyPosts(
-          clubMemberID: MemberController.to.clubMember().id,
-          page: _currentPage1);
-      setState(() {
-        _myPosts.addAll(newPosts);
-        _currentPage1++;
-        _isLoading = false;
-      });
-    } catch (e) {
-      setState(() {
-        _isLoading = false;
-      });
-      print('Error fetching posts: $e');
-    }
-  }
-
-  Future<void> _fetchMyComments(int postId) async {
-    setState(() {
-      _isLoading = true;
-    });
-
-    try {
-      List<Comment>? comments =
-          await PostCommentApiService.fetchMyComments(postId);
-      if (comments != null) {
-        setState(() {
-          _postComments = comments;
-        });
-      }
-      setState(() {
-        _isLoading = false;
-      });
-    } catch (e) {
-      setState(() {
-        _isLoading = false;
-      });
-      print('Error fetching comments: $e');
-    }
-  }
-
-  Future<void> _fetchLikedPosts() async {
-    setState(() {
-      _isLoading = true;
-    });
-
-    try {
-      List<Post> likedPosts = await PostApiService.fetchLikedPosts(
-          clubMemberID: MemberController.to.clubMember().id,
-          page: _currentPage2);
-      setState(() {
-        _likedPosts.addAll(likedPosts);
-        _currentPage2++;
-      });
-    } catch (e) {
-      print('Error fetching posts: $e');
-    } finally {
-      setState(() {
-        _isLoading = false;
-      });
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -148,7 +40,7 @@ class _MyActivityCheckPageState extends State<MyActivityCheckPage> {
             "내 게시글",
           ),
           Text(
-            "내 댓글",
+            "댓글 단 글",
           ),
           Text(
             "좋아요한 글",
@@ -162,85 +54,11 @@ class _MyActivityCheckPageState extends State<MyActivityCheckPage> {
             labelStyle: TextStyle(fontWeight: FontWeight.w600, fontSize: 16),
             unselectedLabelColor: AppColor.textColor,
             unselectedLabelStyle:
-                TextStyle(fontWeight: FontWeight.w600, fontSize: 16)),
-        views: [
-          Container(
-            color: AppColor.backgroundColor2,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(18, 24, 24, 24),
-              child: ListView.builder(
-                controller: _scrollController,
-                itemCount: _myPosts.length + (_isLoading ? 1 : 0),
-                itemBuilder: (context, index) {
-                  if (index < _myPosts.length) {
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 12.0),
-                      child: PostMiniCard(
-                        id: _myPosts[index].id,
-                        title: _myPosts[index].title ?? '제목 없음',
-                        content: _myPosts[index].content,
-                        dateTime: _myPosts[index].createdTime,
-                        isPhoto: _myPosts[index].attachmentsUrl.isNotEmpty,
-                      ),
-                    );
-                  } else {
-                    return Center(
-                      child: CircularProgressIndicator(),
-                    );
-                  }
-                },
-              ),
-            ),
-          ),
-          _isLoading
-              ? Center(child: CircularProgressIndicator())
-              : _postComments.isEmpty
-                  ? Center(child: Text('댓글이 없습니다.'))
-                  : Container(
-                      color: AppColor.backgroundColor2,
-                      child: Padding(
-                        padding: const EdgeInsets.fromLTRB(18, 24, 24, 24),
-                        child: ListView.builder(
-                          itemCount: _postComments.length,
-                          itemBuilder: (context, index) {
-                            return Padding(
-                              padding: const EdgeInsets.only(bottom: 12.0),
-                              child: CommentCard(
-                                comment: _postComments[index],
-                              ),
-                            );
-                          },
-                        ),
-                      ),
-                    ),
-          Container(
-            color: AppColor.backgroundColor2,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(18, 24, 24, 24),
-              child: ListView.builder(
-                controller: _scrollController,
-                itemCount: _likedPosts.length + (_isLoading ? 1 : 0),
-                itemBuilder: (context, index) {
-                  if (index < _likedPosts.length) {
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 12.0),
-                      child: PostMiniCard(
-                        id: _likedPosts[index].id,
-                        title: _likedPosts[index].title ?? '제목 없음',
-                        content: _likedPosts[index].content,
-                        dateTime: _likedPosts[index].createdTime,
-                        isPhoto: _likedPosts[index].attachmentsUrl.isNotEmpty,
-                      ),
-                    );
-                  } else {
-                    return Center(
-                      child: CircularProgressIndicator(),
-                    );
-                  }
-                },
-              ),
-            ),
-          ),
+            TextStyle(fontWeight: FontWeight.w600, fontSize: 16)),
+        views: const [
+          MyActivityPosts(fetchPosts: PostApiService.fetchMyPosts),
+          MyActivityPosts(fetchPosts: PostApiService.fetchCommentedPosts),
+          MyActivityPosts(fetchPosts: PostApiService.fetchLikedPosts),
         ],
       ),
     );

--- a/dplanner/lib/pages/post_page.dart
+++ b/dplanner/lib/pages/post_page.dart
@@ -71,7 +71,7 @@ class _PostPageState extends State<PostPage> {
     });
   }
 
-  void _handleCommentSelected(int commentId) {
+  void _handleCommentSelected(int? commentId) {
     setState(() {
       _replyingCommentId = commentId;
     });

--- a/dplanner/lib/pages/post_page.dart
+++ b/dplanner/lib/pages/post_page.dart
@@ -179,6 +179,7 @@ class _PostPageState extends State<PostPage> {
                                 FocusScope.of(context).requestFocus(
                                     FocusNode()); //TODO: 체크해라 dismiss 되는지
                               }
+                              _fetchComments();
                             },
                             child: _isFocused
                                 ? const Icon(

--- a/dplanner/lib/pages/post_page.dart
+++ b/dplanner/lib/pages/post_page.dart
@@ -1,3 +1,4 @@
+import 'package:dplanner/pages/loading_page.dart';
 import 'package:dplanner/widgets/post_comment.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_sfsymbols/flutter_sfsymbols.dart';
@@ -22,9 +23,9 @@ import 'package:dplanner/controllers/member.dart';
 ///
 
 class PostPage extends StatefulWidget {
-  final Post post;
+  final int postId;
 
-  const PostPage({Key? key, required this.post}) : super(key: key);
+  const PostPage({Key? key, required this.postId}) : super(key: key);
 
   @override
   State<PostPage> createState() => _PostPageState();
@@ -37,18 +38,17 @@ class _PostPageState extends State<PostPage> {
   bool _isReplying = false; //답글을 다는 중인지 체크
   int? _replyingCommentId; //답글을 달려고 클릭한 댓글의 ID
   List<Comment> _comments = [];
-  late Post post; // 상태 변수로 'post' 선언
+  Post? post; // 상태 변수로 'post' 선언
 
   @override
   void initState() {
     super.initState();
-    post = widget.post; // 초기화에서 widget의 post를 사용하여 상태 변수 초기화
-    _fetchComments();
+    _fetchPost();
   }
 
-  Future<void> refreshPost() async {
+  Future<void> _fetchPost() async {
     final updatedPost =
-        await PostApiService.fetchPost(postID: post.id); // post를 새로 로드
+        await PostApiService.fetchPost(postID: widget.postId); // post를 새로 로드
     setState(() {
       post = updatedPost; // 상태 업데이트
       _fetchComments();
@@ -56,7 +56,7 @@ class _PostPageState extends State<PostPage> {
   }
 
   Future<void> _fetchComments() async {
-    final comments = await PostCommentApiService.fetchComments(post.id);
+    final comments = await PostCommentApiService.fetchComments(widget.postId);
     if (comments != null) {
       setState(() {
         _comments = comments;
@@ -100,18 +100,20 @@ class _PostPageState extends State<PostPage> {
           ),
         ),
         body: SafeArea(
-            child: Column(
+            child: post == null
+            ? const LoadingPage() // constraints 없어도 되나?
+            : Column(
           children: [
             Expanded(
                 child: RefreshIndicator(
               onRefresh: () async {
-                refreshPost();
+                _fetchPost();
               },
               child: SingleChildScrollView(
                 physics: const AlwaysScrollableScrollPhysics(),
                 child: Column(
                   children: [
-                    PostContent(post: post),
+                    PostContent(post: post!),
                     Container(
                       color: AppColor.backgroundColor2,
                       height: SizeController.to.screenHeight * 0.01,
@@ -169,7 +171,7 @@ class _PostPageState extends State<PostPage> {
                                 // 폼이 유효한 경우 댓글을 서버에 게시
                                 print("==parentID: ${_replyingCommentId}");
                                 await PostCommentApiService.postComment(
-                                    postId: post.id,
+                                    postId: widget.postId,
                                     content: addComment.text,
                                     parentId: _replyingCommentId);
                                 // 댓글 입력 필드 초기화
@@ -179,7 +181,7 @@ class _PostPageState extends State<PostPage> {
                                 FocusScope.of(context).requestFocus(
                                     FocusNode()); //TODO: 체크해라 dismiss 되는지
                               }
-                              _fetchComments();
+                              _fetchPost(); // 댓글 단 후 게시글 새로고침
                             },
                             child: _isFocused
                                 ? const Icon(

--- a/dplanner/lib/pages/post_page.dart
+++ b/dplanner/lib/pages/post_page.dart
@@ -81,7 +81,7 @@ class _PostPageState extends State<PostPage> {
                 icon: const Icon(SFSymbols.chevron_left)),
             title: const Text(
               "게시글",
-              style: TextStyle(fontWeight: FontWeight.w700, fontSize: 20),
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
             ),
             centerTitle: true,
           ),

--- a/dplanner/lib/pages/post_page.dart
+++ b/dplanner/lib/pages/post_page.dart
@@ -120,6 +120,7 @@ class _PostPageState extends State<PostPage> {
                     ),
                     PostComment(
                         comments: _comments,
+                        selectedCommentId: _replyingCommentId,
                         onCommentSelected: _handleCommentSelected),
                   ],
                 ),

--- a/dplanner/lib/services/club_post_api_service.dart
+++ b/dplanner/lib/services/club_post_api_service.dart
@@ -153,6 +153,25 @@ class PostApiService {
     }
   }
 
+  static Future<List<Post>> fetchLikedPosts(
+    {required int clubMemberID, required int page}) async {
+    final storage = FlutterSecureStorage();
+    final accessToken = await storage.read(key: accessTokenKey);
+
+    final response = await http.get(
+      Uri.parse('$baseUrl/posts/clubMembers/$clubMemberID/like?size=100&page=$page'),
+      headers: {'Authorization': 'Bearer $accessToken'},
+    );
+
+    if (response.statusCode == 200) {
+      final responseData = jsonDecode(utf8.decode(response.bodyBytes));
+      final List<dynamic> content = responseData['data']['content'];
+      return content.map((data) => Post.fromJson(data)).toList();
+    } else {
+      throw Exception('Failed to load posts');
+    }
+  }
+
   static Future<Post> fetchPost({required int postID}) async {
     final storage = FlutterSecureStorage();
     final accessToken = await storage.read(key: accessTokenKey);

--- a/dplanner/lib/services/club_post_api_service.dart
+++ b/dplanner/lib/services/club_post_api_service.dart
@@ -134,8 +134,7 @@ class PostApiService {
 
   static Future<List<Post>> fetchMyPosts(
       //TODO: 포스트 없을때
-      {required int clubMemberID,
-      required int page}) async {
+      {required int clubMemberID, required int page}) async {
     final storage = FlutterSecureStorage();
     final accessToken = await storage.read(key: accessTokenKey);
 
@@ -153,8 +152,28 @@ class PostApiService {
     }
   }
 
+  static Future<List<Post>> fetchCommentedPosts(
+      {required int clubMemberID, required int page}) async {
+    final storage = FlutterSecureStorage();
+    final accessToken = await storage.read(key: accessTokenKey);
+
+    //todo api 나오면 uri 바꾸기
+    final response = await http.get(
+      Uri.parse('$baseUrl/posts/clubMembers/$clubMemberID/commented?size=100&page=$page'),
+      headers: {'Authorization': 'Bearer $accessToken'},
+    );
+
+    if (response.statusCode == 200) {
+      final responseData = jsonDecode(utf8.decode(response.bodyBytes));
+      final List<dynamic> content = responseData['data']['content'];
+      return content.map((data) => Post.fromJson(data)).toList();
+    } else {
+      throw Exception('Failed to load posts');
+    }
+  }
+
   static Future<List<Post>> fetchLikedPosts(
-    {required int clubMemberID, required int page}) async {
+      {required int clubMemberID, required int page}) async {
     final storage = FlutterSecureStorage();
     final accessToken = await storage.read(key: accessTokenKey);
 
@@ -403,12 +422,13 @@ class PostCommentApiService {
     }
   }
 
-  static Future<List<Comment>?> fetchMyComments(int clubMemberId) async {
+  static Future<List<Comment>?> fetchMyComments(
+      {required int clubMemberID}) async {
     final storage = FlutterSecureStorage();
     final accessToken = await storage.read(key: accessTokenKey);
 
     final response = await http.get(
-      Uri.parse('$baseUrl/clubMembers/$clubMemberId/comments'),
+      Uri.parse('$baseUrl/clubMembers/$clubMemberID/comments'),
       headers: {
         'Authorization': 'Bearer $accessToken',
       },

--- a/dplanner/lib/services/club_post_api_service.dart
+++ b/dplanner/lib/services/club_post_api_service.dart
@@ -12,6 +12,8 @@ import '../const.dart';
 import 'package:dplanner/models/post_model.dart';
 import 'package:dplanner/models/post_comment_model.dart';
 
+import '../pages/post_page.dart';
+
 class PostApiService {
   static const String baseUrl = 'http://3.39.102.31:8080';
 
@@ -93,10 +95,11 @@ class PostApiService {
       final responseBody = await http.Response.fromStream(response);
 
       if (response.statusCode == 201) {
-        Get.back();
+        final json = jsonDecode(utf8.decode(responseBody.bodyBytes));
+        final newPost = Post.fromJson(json['data']);
+        Get.off(() => PostPage(postId: newPost.id,), arguments: 1); // 게시글 등록 이후 바로 작성한 게시글로 이동
         // 요청이 성공한 경우
         Get.snackbar('알림', '게시글이 작성되었습니다.');
-        print(responseBody.body);
       } else {
         // 요청이 실패한 경우
         Get.snackbar('알림',

--- a/dplanner/lib/widgets/comment_block.dart
+++ b/dplanner/lib/widgets/comment_block.dart
@@ -27,7 +27,6 @@ class CommentBlock extends StatefulWidget {
 }
 
 class _CommentBlockState extends State<CommentBlock> {
-
   bool _showReplies = false;
 
   void _toggleShowReplies() {
@@ -72,7 +71,8 @@ class _CommentBlockState extends State<CommentBlock> {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Column(
+                    Expanded(
+                        child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
@@ -134,7 +134,7 @@ class _CommentBlockState extends State<CommentBlock> {
                           ],
                         ),
                       ],
-                    ),
+                    )),
                     IconButton(
                       onPressed: () {
                         _commentMore(context, widget.comment);

--- a/dplanner/lib/widgets/comment_block.dart
+++ b/dplanner/lib/widgets/comment_block.dart
@@ -1,0 +1,308 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:dplanner/models/post_comment_model.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_sfsymbols/flutter_sfsymbols.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:get/get.dart';
+import 'package:get/get_core/src/get_main.dart';
+import 'package:intl/intl.dart';
+
+import '../controllers/member.dart';
+import '../controllers/size.dart';
+import '../services/club_post_api_service.dart';
+import '../style.dart';
+import 'nextpage_button.dart';
+
+class CommentBlock extends StatefulWidget {
+  final Function(int) onCommentSelected;
+  final Comment comment;
+
+  const CommentBlock(
+      {Key? key, required this.comment, required this.onCommentSelected})
+      : super(key: key);
+
+  @override
+  State<CommentBlock> createState() => _CommentBlockState();
+}
+
+class _CommentBlockState extends State<CommentBlock> {
+
+  bool _showReplies = false;
+
+  void _toggleShowReplies() {
+    setState(() {
+      _showReplies = !_showReplies;
+    });
+  }
+
+  void _onReplyButtonTapped(int commentId) {
+    widget.onCommentSelected(commentId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(0, 12, 0, 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ClipOval(
+              child: widget.comment.profileUrl != null
+                  ? CachedNetworkImage(
+                      placeholder: (context, url) => Container(),
+                      imageUrl: widget.comment.profileUrl!,
+                      errorWidget: (context, url, error) => SvgPicture.asset(
+                            'assets/images/base_image/base_member_image.svg',
+                          ),
+                      height: SizeController.to.screenWidth * 0.09,
+                      width: SizeController.to.screenWidth * 0.09,
+                      fit: BoxFit.fitHeight)
+                  : SvgPicture.asset(
+                      'assets/images/base_image/base_member_image.svg',
+                      height: SizeController.to.screenWidth * 0.09,
+                      width: SizeController.to.screenWidth * 0.09,
+                      fit: BoxFit.fill,
+                    )),
+          SizedBox(width: SizeController.to.screenWidth * 0.03),
+          Expanded(
+            child: Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Text(
+                              widget.comment.clubMemberName,
+                              style: const TextStyle(
+                                color: AppColor.textColor,
+                                fontWeight: FontWeight.w600,
+                                fontSize: 14,
+                              ),
+                            ),
+                            SizedBox(
+                              width: SizeController.to.screenWidth * 0.05,
+                            ),
+                          ],
+                        ),
+                        Text(
+                          widget.comment.content,
+                          style: const TextStyle(
+                            color: AppColor.textColor,
+                            fontWeight: FontWeight.normal,
+                            fontSize: 14,
+                          ),
+                        ),
+                        Row(
+                          children: [
+                            Text(
+                              DateFormat('M월 dd일')
+                                  .add_jm()
+                                  .format(widget.comment.createdTime),
+                              style: const TextStyle(
+                                color: AppColor.textColor2,
+                                fontWeight: FontWeight.normal,
+                                fontSize: 12,
+                              ),
+                            ),
+                            if (widget.comment.parentId == null)
+                              SizedBox(
+                                width: SizeController.to.screenWidth * 0.03,
+                              ),
+                            if (widget.comment.parentId == null)
+                              InkWell(
+                                onTap: () {
+                                  _onReplyButtonTapped(
+                                      widget.comment.id); //답글이 달리는 댓글의 아이디
+                                },
+                                borderRadius: BorderRadius.circular(5),
+                                child: const Text(
+                                  "답글 달기",
+                                  style: TextStyle(
+                                    color: AppColor.textColor2,
+                                    fontWeight: FontWeight.w500,
+                                    fontSize: 12,
+                                  ),
+                                ),
+                              ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    IconButton(
+                      onPressed: () {
+                        _commentMore(context, widget.comment);
+                      },
+                      icon: const Icon(
+                        SFSymbols.ellipsis,
+                        color: AppColor.textColor,
+                      ),
+                    )
+                  ],
+                ),
+                widget.comment.children.isNotEmpty
+                    ? Column(
+                        children: [
+                          if (_showReplies) ...[
+                            Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: widget.comment.children.map((child) {
+                                // 답글 블록 생성
+                                return CommentBlock(
+                                  comment: child,
+                                  onCommentSelected: widget.onCommentSelected,
+                                );
+                              }).toList(),
+                            ),
+                          ],
+                          Row(
+                            children: [
+                              SvgPicture.asset(
+                                'assets/images/extra/comment_line.svg',
+                              ),
+                              InkWell(
+                                onTap: _toggleShowReplies,
+                                borderRadius: BorderRadius.circular(5),
+                                child: Text(
+                                  _showReplies
+                                      ? "답글 숨기기"
+                                      : "  답글 ${widget.comment.children.length}개 더 보기",
+                                  style: const TextStyle(
+                                    color: AppColor.textColor2,
+                                    fontWeight: FontWeight.w500,
+                                    fontSize: 12,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      )
+                    : Container(),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _commentMore(BuildContext context, Comment comment) async {
+    await showModalBottomSheet(
+      context: context,
+      builder: (BuildContext context) {
+        return Container(
+          height: SizeController.to.screenHeight * 0.3,
+          decoration: const BoxDecoration(
+            color: AppColor.backgroundColor,
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(30),
+              topRight: Radius.circular(30),
+            ),
+          ),
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
+                child: SvgPicture.asset(
+                  'assets/images/extra/showmodal_scrollcontrolbar.svg',
+                ),
+              ),
+              if (comment.clubMemberId == MemberController.to.clubMember().id)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(24, 8, 24, 0),
+                  child: NextPageButton(
+                    buttonColor: AppColor.backgroundColor2,
+                    text: const Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          SFSymbols.pencil_outline,
+                          color: AppColor.textColor,
+                        ),
+                        Text(
+                          " 수정하기",
+                          style: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                              color: AppColor.textColor),
+                        ),
+                      ],
+                    ),
+                    onPressed: () {
+                      Get.back();
+                    },
+                  ),
+                ),
+              comment.clubMemberId == MemberController.to.clubMember().id ||
+                      MemberController.to.clubMember().role == "ADMIN" ||
+                      (MemberController.to.clubMember().clubAuthorityTypes !=
+                              null &&
+                          MemberController.to
+                              .clubMember()
+                              .clubAuthorityTypes!
+                              .contains("POST_ALL"))
+                  ? Padding(
+                      padding: const EdgeInsets.fromLTRB(24, 8, 24, 0),
+                      child: NextPageButton(
+                        buttonColor: AppColor.backgroundColor2,
+                        text: const Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              SFSymbols.trash,
+                              color: AppColor.markColor,
+                            ),
+                            Text(
+                              " 삭제하기",
+                              style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w500,
+                                  color: AppColor.markColor),
+                            ),
+                          ],
+                        ),
+                        onPressed: () {
+                          PostCommentApiService.deleteComment(comment.id);
+                          Get.back();
+                        },
+                      ),
+                    )
+                  : Padding(
+                      padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
+                      child: NextPageButton(
+                        buttonColor: AppColor.backgroundColor2,
+                        text: const Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              SFSymbols.exclamationmark_octagon,
+                              color: AppColor.markColor,
+                            ),
+                            Text(
+                              " 이 댓글 신고하기",
+                              style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w500,
+                                  color: AppColor.markColor),
+                            ),
+                          ],
+                        ),
+                        onPressed: () {
+                          Get.back();
+                        },
+                      ),
+                    ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/dplanner/lib/widgets/comment_block.dart
+++ b/dplanner/lib/widgets/comment_block.dart
@@ -15,11 +15,15 @@ import '../style.dart';
 import 'nextpage_button.dart';
 
 class CommentBlock extends StatefulWidget {
-  final Function(int) onCommentSelected;
+  final bool isSelected;
+  final Function(int?) onCommentSelected;
   final Comment comment;
 
   const CommentBlock(
-      {Key? key, required this.comment, required this.onCommentSelected})
+      {Key? key,
+        required this.isSelected,
+        required this.comment,
+        required this.onCommentSelected})
       : super(key: key);
 
   @override
@@ -36,159 +40,172 @@ class _CommentBlockState extends State<CommentBlock> {
   }
 
   void _onReplyButtonTapped(int commentId) {
-    widget.onCommentSelected(commentId);
+    int? selectedCommentId;
+
+    // 선택된 상태에서 답글달기 다시 누르면 선택 해제
+    if (!widget.isSelected) {
+      selectedCommentId = commentId;
+    }
+
+    widget.onCommentSelected(selectedCommentId);
   }
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(0, 12, 0, 12),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          ClipOval(
-              child: widget.comment.profileUrl != null
-                  ? CachedNetworkImage(
-                      placeholder: (context, url) => Container(),
-                      imageUrl: widget.comment.profileUrl!,
-                      errorWidget: (context, url, error) => SvgPicture.asset(
-                            'assets/images/base_image/base_member_image.svg',
-                          ),
-                      height: SizeController.to.screenWidth * 0.09,
-                      width: SizeController.to.screenWidth * 0.09,
-                      fit: BoxFit.fitHeight)
-                  : SvgPicture.asset(
-                      'assets/images/base_image/base_member_image.svg',
-                      height: SizeController.to.screenWidth * 0.09,
-                      width: SizeController.to.screenWidth * 0.09,
-                      fit: BoxFit.fill,
-                    )),
-          SizedBox(width: SizeController.to.screenWidth * 0.03),
-          Expanded(
-            child: Column(
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Expanded(
-                        child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          children: [
-                            Text(
-                              widget.comment.clubMemberName,
-                              style: const TextStyle(
-                                color: AppColor.textColor,
-                                fontWeight: FontWeight.w600,
-                                fontSize: 14,
-                              ),
+    return Container(
+      // todo 하이라이트 색상이 기본 프사 배경색이랑 겹치는듯
+      color: widget.isSelected ? AppColor.subColor2 : null,
+      child: Padding(
+        padding: widget.comment.parentId == null
+            ? const EdgeInsets.fromLTRB(24, 12, 24, 12)   // 댓글일때
+            : const EdgeInsets.fromLTRB(0, 12, 0, 12),    // 답글일때
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ClipOval(
+                child: widget.comment.profileUrl != null
+                    ? CachedNetworkImage(
+                        placeholder: (context, url) => Container(),
+                        imageUrl: widget.comment.profileUrl!,
+                        errorWidget: (context, url, error) => SvgPicture.asset(
+                              'assets/images/base_image/base_member_image.svg',
                             ),
-                            SizedBox(
-                              width: SizeController.to.screenWidth * 0.05,
-                            ),
-                          ],
-                        ),
-                        Text(
-                          widget.comment.content,
-                          style: const TextStyle(
-                            color: AppColor.textColor,
-                            fontWeight: FontWeight.normal,
-                            fontSize: 14,
-                          ),
-                        ),
-                        Row(
-                          children: [
-                            Text(
-                              DateFormat('M월 dd일')
-                                  .add_jm()
-                                  .format(widget.comment.createdTime),
-                              style: const TextStyle(
-                                color: AppColor.textColor2,
-                                fontWeight: FontWeight.normal,
-                                fontSize: 12,
-                              ),
-                            ),
-                            if (widget.comment.parentId == null)
-                              SizedBox(
-                                width: SizeController.to.screenWidth * 0.03,
-                              ),
-                            if (widget.comment.parentId == null)
-                              InkWell(
-                                onTap: () {
-                                  _onReplyButtonTapped(
-                                      widget.comment.id); //답글이 달리는 댓글의 아이디
-                                },
-                                borderRadius: BorderRadius.circular(5),
-                                child: const Text(
-                                  "답글 달기",
-                                  style: TextStyle(
-                                    color: AppColor.textColor2,
-                                    fontWeight: FontWeight.w500,
-                                    fontSize: 12,
-                                  ),
-                                ),
-                              ),
-                          ],
-                        ),
-                      ],
-                    )),
-                    IconButton(
-                      onPressed: () {
-                        _commentMore(context, widget.comment);
-                      },
-                      icon: const Icon(
-                        SFSymbols.ellipsis,
-                        color: AppColor.textColor,
-                      ),
-                    )
-                  ],
-                ),
-                widget.comment.children.isNotEmpty
-                    ? Column(
+                        height: SizeController.to.screenWidth * 0.09,
+                        width: SizeController.to.screenWidth * 0.09,
+                        fit: BoxFit.fitHeight)
+                    : SvgPicture.asset(
+                        'assets/images/base_image/base_member_image.svg',
+                        height: SizeController.to.screenWidth * 0.09,
+                        width: SizeController.to.screenWidth * 0.09,
+                        fit: BoxFit.fill,
+                      )),
+            SizedBox(width: SizeController.to.screenWidth * 0.03),
+            Expanded(
+              child: Column(
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                          child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          if (_showReplies) ...[
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: widget.comment.children.map((child) {
-                                // 답글 블록 생성
-                                return CommentBlock(
-                                  comment: child,
-                                  onCommentSelected: widget.onCommentSelected,
-                                );
-                              }).toList(),
-                            ),
-                          ],
                           Row(
                             children: [
-                              SvgPicture.asset(
-                                'assets/images/extra/comment_line.svg',
-                              ),
-                              InkWell(
-                                onTap: _toggleShowReplies,
-                                borderRadius: BorderRadius.circular(5),
-                                child: Text(
-                                  _showReplies
-                                      ? "답글 숨기기"
-                                      : "  답글 ${widget.comment.children.length}개 더 보기",
-                                  style: const TextStyle(
-                                    color: AppColor.textColor2,
-                                    fontWeight: FontWeight.w500,
-                                    fontSize: 12,
-                                  ),
+                              Text(
+                                widget.comment.clubMemberName,
+                                style: const TextStyle(
+                                  color: AppColor.textColor,
+                                  fontWeight: FontWeight.w600,
+                                  fontSize: 14,
                                 ),
+                              ),
+                              SizedBox(
+                                width: SizeController.to.screenWidth * 0.05,
                               ),
                             ],
                           ),
+                          Text(
+                            widget.comment.content,
+                            style: const TextStyle(
+                              color: AppColor.textColor,
+                              fontWeight: FontWeight.normal,
+                              fontSize: 14,
+                            ),
+                          ),
+                          Row(
+                            children: [
+                              Text(
+                                DateFormat('M월 dd일')
+                                    .add_jm()
+                                    .format(widget.comment.createdTime),
+                                style: const TextStyle(
+                                  color: AppColor.textColor2,
+                                  fontWeight: FontWeight.normal,
+                                  fontSize: 12,
+                                ),
+                              ),
+                              if (widget.comment.parentId == null)
+                                SizedBox(
+                                  width: SizeController.to.screenWidth * 0.03,
+                                ),
+                              if (widget.comment.parentId == null)
+                                InkWell(
+                                  onTap: () {
+                                    _onReplyButtonTapped(widget.comment.id); //답글이 달리는 댓글의 아이디
+                                  },
+                                  borderRadius: BorderRadius.circular(5),
+                                  child: const Text(
+                                    "답글 달기",
+                                    style: TextStyle(
+                                      color: AppColor.textColor2,
+                                      fontWeight: FontWeight.w500,
+                                      fontSize: 12,
+                                    ),
+                                  ),
+                                ),
+                            ],
+                          ),
                         ],
+                      )),
+                      IconButton(
+                        onPressed: () {
+                          _commentMore(context, widget.comment);
+                        },
+                        icon: const Icon(
+                          SFSymbols.ellipsis,
+                          color: AppColor.textColor,
+                        ),
                       )
-                    : Container(),
-              ],
+                    ],
+                  ),
+                  widget.comment.children.isNotEmpty
+                      ? Column(
+                          children: [
+                            if (_showReplies) ...[
+                              Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: widget.comment.children.map((child) {
+                                  // 답글 블록 생성
+                                  return CommentBlock(
+                                    isSelected: false,
+                                    onCommentSelected: widget.onCommentSelected,
+                                    comment: child,
+                                  );
+                                }).toList(),
+                              ),
+                            ],
+                            Row(
+                              children: [
+                                SvgPicture.asset(
+                                  'assets/images/extra/comment_line.svg',
+                                ),
+                                InkWell(
+                                  onTap: _toggleShowReplies,
+                                  borderRadius: BorderRadius.circular(5),
+                                  child: Text(
+                                    _showReplies
+                                        ? "답글 숨기기"
+                                        : "  답글 ${widget.comment.children.length}개 더 보기",
+                                    style: const TextStyle(
+                                      color: AppColor.textColor2,
+                                      fontWeight: FontWeight.w500,
+                                      fontSize: 12,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        )
+                      : Container(),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/dplanner/lib/widgets/my_activity_posts.dart
+++ b/dplanner/lib/widgets/my_activity_posts.dart
@@ -1,0 +1,148 @@
+import 'dart:async';
+
+import 'package:dplanner/controllers/member.dart';
+import 'package:dplanner/models/post_model.dart';
+import 'package:dplanner/widgets/post_mini_card.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import '../pages/error_page.dart';
+import '../pages/loading_page.dart';
+import '../style.dart';
+
+class MyActivityPosts extends StatefulWidget {
+  final Future<List<Post>> Function(
+      {required int clubMemberID, required int page}) fetchPosts;
+
+  const MyActivityPosts({super.key, required this.fetchPosts});
+
+  @override
+  State<MyActivityPosts> createState() => _MyActivityPostsState();
+}
+
+class _MyActivityPostsState extends State<MyActivityPosts> {
+  final List<Post> _posts = [];
+  int _currentPage = 0;
+  bool _hasNextPage = true;
+  bool _isLoading = false;
+
+  final StreamController<List<Post>> _postsController =
+      StreamController<List<Post>>();
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchPosts();
+  }
+
+  @override
+  void dispose() {
+    _postsController.close();
+    super.dispose();
+  }
+
+  void _fetchPosts() async {
+    if (!_hasNextPage) return;
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    if (_currentPage == 0) _posts.clear();
+
+    List<Post> posts = await widget.fetchPosts(
+        clubMemberID: MemberController.to.clubMember().id, page: _currentPage);
+
+    setState(() {
+      _isLoading = false;
+    });
+
+    if (posts.isNotEmpty) {
+      setState(() {
+        _posts.addAll(posts);
+      });
+      _postsController.add(_posts);
+    } else {
+      _hasNextPage = false; // 받아온 포스트가 없다면, 다음 페이지가 없는 것으로 간주합니다.
+    }
+  }
+
+  void _onScrollNotification(ScrollNotification scrollInfo) {
+    if (scrollInfo is ScrollEndNotification &&
+        scrollInfo.metrics.pixels == scrollInfo.metrics.maxScrollExtent) {
+      _fetchPosts(); // 스크롤이 끝에 도달하면 다음 페이지의 포스트를 로드
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+        builder: (context, constraints) => RefreshIndicator(
+            onRefresh: () async {
+              setState(() {
+                _currentPage = 0;
+              });
+              _fetchPosts();
+            },
+            child: SingleChildScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              child: NotificationListener<ScrollNotification>(
+                  onNotification: (ScrollNotification scrollInfo) {
+                    _onScrollNotification(scrollInfo);
+                    return true;
+                  },
+                  child: StreamBuilder<List<Post>>(
+                      stream: _postsController.stream,
+                      builder: (BuildContext context,
+                          AsyncSnapshot<List<Post>> snapshot) {
+                        if (snapshot.data == null && !_isLoading) {
+                          return ConstrainedBox(
+                            constraints: BoxConstraints(
+                                minHeight: constraints.maxHeight),
+                            child: const Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Center(
+                                  child: Text(
+                                    "게시글이 없어요",
+                                    style: TextStyle(
+                                        fontWeight: FontWeight.w600,
+                                        fontSize: 16),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                        } else if (snapshot.hasError) {
+                          return ErrorPage(constraints: constraints);
+                        } else if (snapshot.connectionState ==
+                                ConnectionState.waiting &&
+                            snapshot.hasData == false) {
+                          return LoadingPage(constraints: constraints);
+                        } else {
+                          return Container(
+                            color: AppColor.backgroundColor2,
+                            child: Padding(
+                              padding: const EdgeInsets.fromLTRB(18, 24, 24, 24),
+                              child: Column(
+                                children: List.generate(
+                                    snapshot.data!.length,
+                                    (index) => Padding(
+                                      padding: const EdgeInsets.only(bottom: 12.0),
+                                      child: PostMiniCard(
+                                        id: snapshot.data![index].id,
+                                        title: snapshot.data![index].title ?? '제목 없음',
+                                        content: snapshot.data![index].content,
+                                        dateTime: snapshot.data![index].createdTime,
+                                        isPhoto: snapshot.data![index].attachmentsUrl.isNotEmpty,
+                                      ),
+                                    )
+                                ),
+                                  )
+                              )
+                            );
+                        }
+                      })),
+            )));
+  }
+}

--- a/dplanner/lib/widgets/post_card.dart
+++ b/dplanner/lib/widgets/post_card.dart
@@ -41,9 +41,25 @@ class _PostCardState extends State<PostCard> {
     });
   }
 
+  int _getPostCardContentLength(String content) {
+    const contentCutoff = 100;
+    if (content.length > contentCutoff) return contentCutoff;
+
+    int newLineCount = 0;
+    for (int i = 0; i < content.length; i++) {
+      if (content[i] == '\n') {
+        newLineCount++;
+        if (newLineCount > 3) return i;
+      }
+    }
+
+    return content.length;
+  }
+
+
   Widget buildPostContent(String content) {
-    final cutoff = 100;
-    final shouldShowMore = content.length > cutoff;
+    final postCardContentLength = _getPostCardContentLength(content);
+    final shouldShowMore = postCardContentLength < content.length;
 
     return RichText(
       text: TextSpan(
@@ -54,7 +70,7 @@ class _PostCardState extends State<PostCard> {
         ),
         children: <TextSpan>[
           TextSpan(
-            text: shouldShowMore ? content.substring(0, cutoff) : content,
+            text: content.substring(0, postCardContentLength),
           ),
           if (shouldShowMore)
             const TextSpan(

--- a/dplanner/lib/widgets/post_card.dart
+++ b/dplanner/lib/widgets/post_card.dart
@@ -32,7 +32,7 @@ class _PostCardState extends State<PostCard> {
       text: TextSpan(
         style: const TextStyle(
           color: AppColor.textColor,
-          fontWeight: FontWeight.w600,
+          fontWeight: FontWeight.normal,
           fontSize: 16,
         ),
         children: <TextSpan>[
@@ -107,7 +107,7 @@ class _PostCardState extends State<PostCard> {
                               widget.post.clubMemberName,
                               style: const TextStyle(
                                 color: AppColor.textColor,
-                                fontWeight: FontWeight.w600,
+                                fontWeight: FontWeight.bold,
                                 fontSize: 16,
                               ),
                             ),
@@ -117,7 +117,7 @@ class _PostCardState extends State<PostCard> {
                                   .format(widget.post.createdTime),
                               style: const TextStyle(
                                 color: AppColor.textColor,
-                                fontWeight: FontWeight.w500,
+                                fontWeight: FontWeight.normal,
                                 fontSize: 12,
                               ),
                             ),
@@ -137,7 +137,7 @@ class _PostCardState extends State<PostCard> {
                               '관리자',
                               style: TextStyle(
                                 color: AppColor.backgroundColor,
-                                fontWeight: FontWeight.w400,
+                                fontWeight: FontWeight.normal,
                                 fontSize: 11,
                               ),
                             ),
@@ -158,7 +158,7 @@ class _PostCardState extends State<PostCard> {
                             : "제목 없음", //제목 생기면 그때 수정할 것
                         style: const TextStyle(
                           color: AppColor.textColor,
-                          fontWeight: FontWeight.w800,
+                          fontWeight: FontWeight.bold,
                           fontSize: 20,
                         ),
                       ),
@@ -174,17 +174,18 @@ class _PostCardState extends State<PostCard> {
                         ? const Expanded(
                             flex: 1,
                             child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.center,
                               children: [
                                 Icon(
                                   SFSymbols.pin_fill,
-                                  color: AppColor.textColor2,
+                                  color: AppColor.objectColor,
                                   size: 14,
                                 ),
                                 Text(
                                   '고정됨',
                                   style: TextStyle(
-                                    color: AppColor.textColor2,
-                                    fontWeight: FontWeight.w500,
+                                    color: AppColor.objectColor,
+                                    fontWeight: FontWeight.bold,
                                     fontSize: 14,
                                   ),
                                 ),
@@ -210,7 +211,7 @@ class _PostCardState extends State<PostCard> {
                               '${widget.post.commentCount}',
                               style: const TextStyle(
                                 color: AppColor.textColor2,
-                                fontWeight: FontWeight.w500,
+                                fontWeight: FontWeight.normal,
                                 fontSize: 16,
                               ),
                             ),
@@ -231,7 +232,7 @@ class _PostCardState extends State<PostCard> {
                               '${widget.post.likeCount}',
                               style: const TextStyle(
                                 color: AppColor.textColor2,
-                                fontWeight: FontWeight.w500,
+                                fontWeight: FontWeight.normal,
                                 fontSize: 16,
                               ),
                             ),

--- a/dplanner/lib/widgets/post_card.dart
+++ b/dplanner/lib/widgets/post_card.dart
@@ -45,7 +45,7 @@ class _PostCardState extends State<PostCard> {
               text: '... 더 보기',
               style: TextStyle(
                 color: AppColor.subColor3,
-                fontWeight: FontWeight.bold,
+                fontWeight: FontWeight.normal,
               ),
             ),
         ],

--- a/dplanner/lib/widgets/post_card.dart
+++ b/dplanner/lib/widgets/post_card.dart
@@ -17,6 +17,7 @@ import 'package:dplanner/models/post_model.dart';
 ///
 class PostCard extends StatefulWidget {
   final Post post;
+
   const PostCard({Key? key, required this.post}) : super(key: key);
 
   @override
@@ -218,23 +219,33 @@ class _PostCardState extends State<PostCard> {
                           ),
                           Expanded(
                             flex: 1,
-                            child: Icon(
-                              widget.post.likeStatus
-                                  ? SFSymbols.heart_fill
-                                  : SFSymbols.heart,
-                              color: AppColor.textColor2,
-                              size: 16,
-                            ),
+                            child: widget.post.likeStatus
+                                ? const Icon(
+                                    SFSymbols.heart_fill,
+                                    color: AppColor.objectColor,
+                                    size: 16,
+                                  )
+                                : const Icon(
+                                    SFSymbols.heart,
+                                    color: AppColor.textColor2,
+                                    size: 16,
+                                  ),
                           ),
                           Expanded(
                             flex: 1,
                             child: Text(
                               '${widget.post.likeCount}',
-                              style: const TextStyle(
-                                color: AppColor.textColor2,
-                                fontWeight: FontWeight.normal,
-                                fontSize: 16,
-                              ),
+                              style: widget.post.likeStatus
+                                  ? const TextStyle(
+                                      color: AppColor.objectColor,
+                                      fontWeight: FontWeight.normal,
+                                      fontSize: 16,
+                                    )
+                                  : const TextStyle(
+                                      color: AppColor.textColor2,
+                                      fontWeight: FontWeight.normal,
+                                      fontSize: 16,
+                                    ),
                             ),
                           ),
                         ],

--- a/dplanner/lib/widgets/post_comment.dart
+++ b/dplanner/lib/widgets/post_comment.dart
@@ -1,351 +1,51 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_sfsymbols/flutter_sfsymbols.dart';
-import 'package:flutter_svg/svg.dart';
-import 'package:get/get.dart';
-import 'package:intl/intl.dart';
 
-import '../controllers/member.dart';
 import '../controllers/size.dart';
 import '../style.dart';
-import 'nextpage_button.dart';
-import 'package:dplanner/models/post_model.dart';
+import 'comment_block.dart';
 import 'package:dplanner/models/post_comment_model.dart';
-import 'package:dplanner/services/club_post_api_service.dart';
 
 ///
 ///
 /// POST 자세히보기 화면에서 댓글 내용 그리는 class
 ///
 ///
-class PostComment extends StatefulWidget {
+class PostComment extends StatelessWidget {
   final Function(int) onCommentSelected;
-  final Post post;
+  final List<Comment> comments;
+
   const PostComment(
-      {Key? key, required this.post, required this.onCommentSelected})
+      {Key? key, required this.comments, required this.onCommentSelected})
       : super(key: key);
-
-  @override
-  State<PostComment> createState() => _PostCommentState();
-}
-
-class _PostCommentState extends State<PostComment> {
-  List<Comment>? _comments;
-  bool showReplies = false;
-  Map<int, bool>? showRepliesMap = {};
-
-  @override
-  void initState() {
-    super.initState();
-    _fetchComments();
-  }
-
-  void _onReplyButtonTapped(int commentId) {
-    widget.onCommentSelected(commentId);
-  }
-
-  Future<void> _fetchComments() async {
-    final comments = await PostCommentApiService.fetchComments(widget.post.id);
-    if (comments != null)
-      setState(() {
-        _comments = comments;
-        showRepliesMap = Map.fromIterable(
-          comments!.whereType<Comment>(), // Filter out null values if any
-          key: (comment) => (comment as Comment).id,
-          value: (_) => false,
-        );
-      });
-  }
 
   @override
   Widget build(BuildContext context) {
     return Container(
       width: SizeController.to.screenWidth,
       color: AppColor.backgroundColor,
-      child: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: _comments == null
-              ? [
-                  const Center(
-                    child: Text(
-                      "댓글이 없습니다",
-                    ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: comments.isEmpty
+            ? [
+                const SizedBox(
+                  height: 24,
+                ),
+                const Center(
+                  child: Text(
+                    "댓글이 없습니다",
                   ),
-                ]
-              : [
-                  // 댓글 데이터를 화면에 표시하는 부분
-                  for (var comment in _comments!) commentBlock(comment),
-                ],
-        ),
-      ),
-    );
-  }
-
-  Widget commentBlock(Comment comment) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        ClipOval(
-            child: comment.profileUrl != null
-                ? CachedNetworkImage(
-                    placeholder: (context, url) => Container(),
-                    imageUrl: comment.profileUrl!,
-                    errorWidget: (context, url, error) => SvgPicture.asset(
-                          'assets/images/base_image/base_member_image.svg',
-                        ),
-                    height: SizeController.to.screenWidth * 0.09,
-                    width: SizeController.to.screenWidth * 0.09,
-                    fit: BoxFit.fitHeight)
-                : SvgPicture.asset(
-                    'assets/images/base_image/base_member_image.svg',
-                    height: SizeController.to.screenWidth * 0.09,
-                    width: SizeController.to.screenWidth * 0.09,
-                    fit: BoxFit.fill,
-                  )),
-        SizedBox(width: SizeController.to.screenWidth * 0.03),
-        Expanded(
-          child: Column(
-            children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          Text(
-                            comment.clubMemberName,
-                            style: TextStyle(
-                              color: AppColor.textColor,
-                              fontWeight: FontWeight.w600,
-                              fontSize: 14,
-                            ),
-                          ),
-                          SizedBox(
-                            width: SizeController.to.screenWidth * 0.05,
-                          ),
-                        ],
-                      ),
-                      Text(
-                        comment.content,
-                        style: TextStyle(
-                          color: AppColor.textColor,
-                          fontWeight: FontWeight.normal,
-                          fontSize: 14,
-                        ),
-                      ),
-                      Row(
-                        children: [
-                          Text(
-                            DateFormat('M월 dd일')
-                                .add_jm()
-                                .format(comment.createdTime),
-                            style: TextStyle(
-                              color: AppColor.textColor2,
-                              fontWeight: FontWeight.normal,
-                              fontSize: 12,
-                            ),
-                          ),
-                          if (comment.parentId == null)
-                            SizedBox(
-                              width: SizeController.to.screenWidth * 0.03,
-                            ),
-                          if (comment.parentId == null)
-                            InkWell(
-                              onTap: () {
-                                _onReplyButtonTapped(
-                                    comment.id); //답글이 달리는 댓글의 아이디
-                              },
-                              borderRadius: BorderRadius.circular(5),
-                              child: const Text(
-                                "답글 달기",
-                                style: TextStyle(
-                                  color: AppColor.textColor2,
-                                  fontWeight: FontWeight.w500,
-                                  fontSize: 12,
-                                ),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ],
-                  ),
-                  IconButton(
-                    onPressed: () {
-                      _commentMore(context, comment);
-                    },
-                    icon: const Icon(
-                      SFSymbols.ellipsis,
-                      color: AppColor.textColor,
-                    ),
+                ),
+              ]
+            : [
+                // 댓글 데이터를 화면에 표시하는 부분
+                for (var comment in comments)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(24, 0, 24, 0),
+                    child: CommentBlock(
+                        comment: comment, onCommentSelected: onCommentSelected),
                   )
-                ],
-              ),
-              comment.children.isNotEmpty
-                  ? Column(
-                      children: [
-                        if (showRepliesMap?[comment.id] ?? false) ...[
-                          Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: comment.children.map((child) {
-                              // 답글 블록 생성
-                              return commentBlock(child);
-                            }).toList(),
-                          ),
-                        ],
-                        Row(
-                          children: [
-                            SvgPicture.asset(
-                              'assets/images/extra/comment_line.svg',
-                            ),
-                            InkWell(
-                              onTap: () {
-                                setState(() {
-                                  if (showRepliesMap != null) {
-                                    showRepliesMap![comment.id] =
-                                        !(showRepliesMap![comment.id] ?? false);
-                                  }
-                                });
-                              },
-                              borderRadius: BorderRadius.circular(5),
-                              child: Text(
-                                (showRepliesMap?[comment.id] ?? false)
-                                    ? "답글 숨기기"
-                                    : "  답글 ${comment.children.length}개 더 보기",
-                                style: TextStyle(
-                                  color: AppColor.textColor2,
-                                  fontWeight: FontWeight.w500,
-                                  fontSize: 12,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    )
-                  : Container(),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-
-  void _commentMore(BuildContext context, Comment comment) async {
-    await showModalBottomSheet(
-      context: context,
-      builder: (BuildContext context) {
-        return Container(
-          height: SizeController.to.screenHeight * 0.3,
-          decoration: const BoxDecoration(
-            color: AppColor.backgroundColor,
-            borderRadius: BorderRadius.only(
-              topLeft: Radius.circular(30),
-              topRight: Radius.circular(30),
-            ),
-          ),
-          child: Column(
-            children: [
-              Padding(
-                padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
-                child: SvgPicture.asset(
-                  'assets/images/extra/showmodal_scrollcontrolbar.svg',
-                ),
-              ),
-              if (comment.clubMemberId == MemberController.to.clubMember().id)
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(24, 8, 24, 0),
-                  child: NextPageButton(
-                    buttonColor: AppColor.backgroundColor2,
-                    text: const Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(
-                          SFSymbols.pencil_outline,
-                          color: AppColor.textColor,
-                        ),
-                        Text(
-                          " 수정하기",
-                          style: TextStyle(
-                              fontSize: 16,
-                              fontWeight: FontWeight.w500,
-                              color: AppColor.textColor),
-                        ),
-                      ],
-                    ),
-                    onPressed: () {
-                      Get.back();
-                    },
-                  ),
-                ),
-              comment.clubMemberId == MemberController.to.clubMember().id ||
-                      MemberController.to.clubMember().role == "ADMIN" ||
-                      (MemberController.to.clubMember().clubAuthorityTypes !=
-                              null &&
-                          MemberController.to
-                              .clubMember()
-                              .clubAuthorityTypes!
-                              .contains("POST_ALL"))
-                  ? Padding(
-                      padding: const EdgeInsets.fromLTRB(24, 8, 24, 0),
-                      child: NextPageButton(
-                        buttonColor: AppColor.backgroundColor2,
-                        text: const Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Icon(
-                              SFSymbols.trash,
-                              color: AppColor.markColor,
-                            ),
-                            Text(
-                              " 삭제하기",
-                              style: TextStyle(
-                                  fontSize: 16,
-                                  fontWeight: FontWeight.w500,
-                                  color: AppColor.markColor),
-                            ),
-                          ],
-                        ),
-                        onPressed: () {
-                          PostCommentApiService.deleteComment(comment.id);
-                          Get.back();
-                        },
-                      ),
-                    )
-                  : Padding(
-                      padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
-                      child: NextPageButton(
-                        buttonColor: AppColor.backgroundColor2,
-                        text: const Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Icon(
-                              SFSymbols.exclamationmark_octagon,
-                              color: AppColor.markColor,
-                            ),
-                            Text(
-                              " 이 댓글 신고하기",
-                              style: TextStyle(
-                                  fontSize: 16,
-                                  fontWeight: FontWeight.w500,
-                                  color: AppColor.markColor),
-                            ),
-                          ],
-                        ),
-                        onPressed: () {
-                          Get.back();
-                        },
-                      ),
-                    ),
-            ],
-          ),
-        );
-      },
+              ],
+      ),
     );
   }
 }

--- a/dplanner/lib/widgets/post_comment.dart
+++ b/dplanner/lib/widgets/post_comment.dart
@@ -10,28 +10,18 @@ import 'package:dplanner/models/post_comment_model.dart';
 /// POST 자세히보기 화면에서 댓글 내용 그리는 class
 ///
 ///
-class PostComment extends StatefulWidget {
-  final Function(int?) onCommentSelected;
+class PostComment extends StatelessWidget {
   final List<Comment> comments;
+  final int? selectedCommentId;
+  final Function(int?) onCommentSelected;
 
   const PostComment(
-      {Key? key, required this.comments, required this.onCommentSelected})
+      {Key? key,
+        required this.comments,
+        required this.selectedCommentId,
+        required this.onCommentSelected,
+      })
       : super(key: key);
-
-  @override
-  State<PostComment> createState() => _PostCommentState();
-}
-
-class _PostCommentState extends State<PostComment> {
-  int? _selectedCommentId;
-
-  void _handleSelected(int? commentId) {
-    setState(() {
-      _selectedCommentId = commentId;
-    });
-
-    widget.onCommentSelected(_selectedCommentId);
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +30,7 @@ class _PostCommentState extends State<PostComment> {
       color: AppColor.backgroundColor,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: widget.comments.isEmpty
+        children: comments.isEmpty
             ? [
           const SizedBox(
             height: 24,
@@ -53,11 +43,11 @@ class _PostCommentState extends State<PostComment> {
         ]
             : [
           // 댓글 데이터를 화면에 표시하는 부분
-          for (var comment in widget.comments)
+          for (var comment in comments)
             CommentBlock(
-                isSelected: comment.id == _selectedCommentId ? true : false,
+                isSelected: comment.id == selectedCommentId ? true : false,
                 comment: comment,
-                onCommentSelected: _handleSelected
+                onCommentSelected: onCommentSelected
             ),
         ],
       ),

--- a/dplanner/lib/widgets/post_comment.dart
+++ b/dplanner/lib/widgets/post_comment.dart
@@ -135,7 +135,7 @@ class _PostCommentState extends State<PostComment> {
                         comment.content,
                         style: TextStyle(
                           color: AppColor.textColor,
-                          fontWeight: FontWeight.w500,
+                          fontWeight: FontWeight.normal,
                           fontSize: 14,
                         ),
                       ),
@@ -147,7 +147,7 @@ class _PostCommentState extends State<PostComment> {
                                 .format(comment.createdTime),
                             style: TextStyle(
                               color: AppColor.textColor2,
-                              fontWeight: FontWeight.w500,
+                              fontWeight: FontWeight.normal,
                               fontSize: 12,
                             ),
                           ),

--- a/dplanner/lib/widgets/post_comment.dart
+++ b/dplanner/lib/widgets/post_comment.dart
@@ -10,13 +10,28 @@ import 'package:dplanner/models/post_comment_model.dart';
 /// POST 자세히보기 화면에서 댓글 내용 그리는 class
 ///
 ///
-class PostComment extends StatelessWidget {
-  final Function(int) onCommentSelected;
+class PostComment extends StatefulWidget {
+  final Function(int?) onCommentSelected;
   final List<Comment> comments;
 
   const PostComment(
       {Key? key, required this.comments, required this.onCommentSelected})
       : super(key: key);
+
+  @override
+  State<PostComment> createState() => _PostCommentState();
+}
+
+class _PostCommentState extends State<PostComment> {
+  int? _selectedCommentId;
+
+  void _handleSelected(int? commentId) {
+    setState(() {
+      _selectedCommentId = commentId;
+    });
+
+    widget.onCommentSelected(_selectedCommentId);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -25,26 +40,26 @@ class PostComment extends StatelessWidget {
       color: AppColor.backgroundColor,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: comments.isEmpty
+        children: widget.comments.isEmpty
             ? [
-                const SizedBox(
-                  height: 24,
-                ),
-                const Center(
-                  child: Text(
-                    "댓글이 없습니다",
-                  ),
-                ),
-              ]
+          const SizedBox(
+            height: 24,
+          ),
+          const Center(
+            child: Text(
+              "댓글이 없습니다",
+            ),
+          ),
+        ]
             : [
-                // 댓글 데이터를 화면에 표시하는 부분
-                for (var comment in comments)
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(24, 0, 24, 0),
-                    child: CommentBlock(
-                        comment: comment, onCommentSelected: onCommentSelected),
-                  )
-              ],
+          // 댓글 데이터를 화면에 표시하는 부분
+          for (var comment in widget.comments)
+            CommentBlock(
+                isSelected: comment.id == _selectedCommentId ? true : false,
+                comment: comment,
+                onCommentSelected: _handleSelected
+            ),
+        ],
       ),
     );
   }

--- a/dplanner/lib/widgets/post_content.dart
+++ b/dplanner/lib/widgets/post_content.dart
@@ -311,22 +311,34 @@ class _PostContentState extends State<PostContent> {
                         flex: 1,
                         child: GestureDetector(
                           onTap: _toggleLike,
-                          child: Icon(
-                            isLiked ? SFSymbols.heart_fill : SFSymbols.heart,
-                            color: AppColor.textColor2,
-                            size: 16,
-                          ),
+                          child: isLiked
+                              ? const Icon(
+                                  SFSymbols.heart_fill,
+                                  color: AppColor.objectColor,
+                                  size: 16,
+                                )
+                              : const Icon(
+                                  SFSymbols.heart,
+                                  color: AppColor.textColor2,
+                                  size: 16,
+                                ),
                         ),
                       ),
                       Expanded(
                         flex: 1,
                         child: Text(
                           '${likeCount}',
-                          style: TextStyle(
-                            color: AppColor.textColor2,
-                            fontWeight: FontWeight.normal,
-                            fontSize: 16,
-                          ),
+                          style: isLiked
+                              ? const TextStyle(
+                                  color: AppColor.objectColor,
+                                  fontWeight: FontWeight.normal,
+                                  fontSize: 16,
+                                )
+                              : const TextStyle(
+                                  color: AppColor.textColor2,
+                                  fontWeight: FontWeight.normal,
+                                  fontSize: 16,
+                                ),
                         ),
                       ),
                     ],

--- a/dplanner/lib/widgets/post_content.dart
+++ b/dplanner/lib/widgets/post_content.dart
@@ -150,7 +150,7 @@ class _PostContentState extends State<PostContent> {
                               widget.post.clubMemberName,
                               style: const TextStyle(
                                 color: AppColor.textColor,
-                                fontWeight: FontWeight.w600,
+                                fontWeight: FontWeight.bold,
                                 fontSize: 16,
                               ),
                             ),
@@ -170,7 +170,7 @@ class _PostContentState extends State<PostContent> {
                                       "관리자",
                                       style: TextStyle(
                                         color: AppColor.backgroundColor,
-                                        fontWeight: FontWeight.w400,
+                                        fontWeight: FontWeight.normal,
                                         fontSize: 11,
                                       ),
                                     ),
@@ -184,7 +184,7 @@ class _PostContentState extends State<PostContent> {
                               .format(widget.post.createdTime),
                           style: const TextStyle(
                             color: AppColor.textColor,
-                            fontWeight: FontWeight.w500,
+                            fontWeight: FontWeight.normal,
                             fontSize: 12,
                           ),
                         ),
@@ -214,7 +214,7 @@ class _PostContentState extends State<PostContent> {
                     widget.post.title ?? "제목없음", //TODO: 제목 생기면 수정해야함
                     style: TextStyle(
                       color: AppColor.textColor,
-                      fontWeight: FontWeight.w800,
+                      fontWeight: FontWeight.bold,
                       fontSize: 20,
                     ),
                   ),
@@ -223,7 +223,7 @@ class _PostContentState extends State<PostContent> {
                   widget.post.content,
                   style: TextStyle(
                     color: AppColor.textColor,
-                    fontWeight: FontWeight.w600,
+                    fontWeight: FontWeight.normal,
                     fontSize: 16,
                   ),
                 ),
@@ -269,14 +269,14 @@ class _PostContentState extends State<PostContent> {
                           children: [
                             Icon(
                               SFSymbols.pin_fill,
-                              color: AppColor.textColor2,
+                              color: AppColor.objectColor,
                               size: 14,
                             ),
                             Text(
                               " 고정됨",
                               style: TextStyle(
-                                color: AppColor.textColor2,
-                                fontWeight: FontWeight.w500,
+                                color: AppColor.objectColor,
+                                fontWeight: FontWeight.bold,
                                 fontSize: 14,
                               ),
                             ),
@@ -302,7 +302,7 @@ class _PostContentState extends State<PostContent> {
                           '${widget.post.commentCount}',
                           style: TextStyle(
                             color: AppColor.textColor2,
-                            fontWeight: FontWeight.w500,
+                            fontWeight: FontWeight.normal,
                             fontSize: 16,
                           ),
                         ),
@@ -324,7 +324,7 @@ class _PostContentState extends State<PostContent> {
                           '${likeCount}',
                           style: TextStyle(
                             color: AppColor.textColor2,
-                            fontWeight: FontWeight.w500,
+                            fontWeight: FontWeight.normal,
                             fontSize: 16,
                           ),
                         ),

--- a/dplanner/lib/widgets/post_mini_card.dart
+++ b/dplanner/lib/widgets/post_mini_card.dart
@@ -1,21 +1,50 @@
 import 'package:dplanner/controllers/size.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:intl/intl.dart';
 
 import '../style.dart';
 
 class PostMiniCard extends StatelessWidget {
   final String title;
   final String content;
-  final String date;
+  final DateTime dateTime;
   final bool isPhoto;
 
   const PostMiniCard(
       {super.key,
       required this.title,
       required this.content,
-      required this.date,
+      required this.dateTime,
       this.isPhoto = false});
+
+  Widget buildPostContent(String content) {
+    final cutoff = 100;
+    final shouldShowMore = content.length > cutoff;
+
+    return RichText(
+      text: TextSpan(
+        style: const TextStyle(
+          color: AppColor.textColor,
+          fontWeight: FontWeight.normal,
+          fontSize: 16,
+        ),
+        children: <TextSpan>[
+          TextSpan(
+            text: shouldShowMore ? content.substring(0, cutoff) : content,
+          ),
+          if (shouldShowMore)
+            const TextSpan(
+              text: '... 더 보기',
+              style: TextStyle(
+                  color: AppColor.subColor3,
+                  fontWeight: FontWeight.normal,
+                  fontSize: 16),
+            ),
+        ],
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -37,22 +66,17 @@ class PostMiniCard extends StatelessWidget {
                     title,
                     style: const TextStyle(
                         color: AppColor.textColor,
-                        fontWeight: FontWeight.w700,
+                        fontWeight: FontWeight.bold,
                         fontSize: 16),
                   ),
+                  buildPostContent(content),
                   Text(
-                    content,
+                    DateFormat('yyyy년 M월 d일').add_jm().format(dateTime),
                     style: const TextStyle(
-                        color: AppColor.textColor,
-                        fontWeight: FontWeight.w500,
-                        fontSize: 14),
-                  ),
-                  Text(
-                    date,
-                    style: const TextStyle(
-                        color: AppColor.textColor,
-                        fontWeight: FontWeight.w500,
-                        fontSize: 12),
+                      color: AppColor.textColor,
+                      fontWeight: FontWeight.normal,
+                      fontSize: 12,
+                    ),
                   ),
                 ],
               ),

--- a/dplanner/lib/widgets/post_mini_card.dart
+++ b/dplanner/lib/widgets/post_mini_card.dart
@@ -1,11 +1,14 @@
 import 'package:dplanner/controllers/size.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:get/get.dart';
 import 'package:intl/intl.dart';
 
+import '../pages/post_page.dart';
 import '../style.dart';
 
 class PostMiniCard extends StatelessWidget {
+  final int id;
   final String title;
   final String content;
   final DateTime dateTime;
@@ -13,6 +16,7 @@ class PostMiniCard extends StatelessWidget {
 
   const PostMiniCard(
       {super.key,
+      required this.id,
       required this.title,
       required this.content,
       required this.dateTime,
@@ -48,48 +52,53 @@ class PostMiniCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: SizeController.to.screenWidth,
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(12),
-        color: AppColor.backgroundColor,
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(18.0),
-        child: Row(
-          children: [
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: const TextStyle(
-                        color: AppColor.textColor,
-                        fontWeight: FontWeight.bold,
-                        fontSize: 16),
-                  ),
-                  buildPostContent(content),
-                  Text(
-                    DateFormat('yyyy년 M월 d일').add_jm().format(dateTime),
-                    style: const TextStyle(
-                      color: AppColor.textColor,
-                      fontWeight: FontWeight.normal,
-                      fontSize: 12,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            if (isPhoto)
-              SvgPicture.asset(
-                'assets/images/base_image/base_post_image.svg',
-                height: 64,
-                width: 64,
-              )
-          ],
+    return InkWell(
+      onTap: () {
+        Get.to(PostPage(postId: id), arguments: 1);
+      },
+      child: Container(
+        width: SizeController.to.screenWidth,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          color: AppColor.backgroundColor,
         ),
-      ),
+        child: Padding(
+          padding: const EdgeInsets.all(18.0),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: const TextStyle(
+                          color: AppColor.textColor,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16),
+                    ),
+                    buildPostContent(content),
+                    Text(
+                      DateFormat('yyyy년 M월 d일').add_jm().format(dateTime),
+                      style: const TextStyle(
+                        color: AppColor.textColor,
+                        fontWeight: FontWeight.normal,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (isPhoto)
+                SvgPicture.asset(
+                  'assets/images/base_image/base_post_image.svg',
+                  height: 64,
+                  width: 64,
+                )
+            ],
+          ),
+        ),
+      )
     );
   }
 }

--- a/dplanner/lib/widgets/post_mini_card.dart
+++ b/dplanner/lib/widgets/post_mini_card.dart
@@ -22,9 +22,24 @@ class PostMiniCard extends StatelessWidget {
       required this.dateTime,
       this.isPhoto = false});
 
+  int _getPostCardContentLength(String content) {
+    const contentCutoff = 100;
+    if (content.length > contentCutoff) return contentCutoff;
+
+    int newLineCount = 0;
+    for (int i = 0; i < content.length; i++) {
+      if (content[i] == '\n') {
+        newLineCount++;
+        if (newLineCount > 3) return i;
+      }
+    }
+
+    return content.length;
+  }
+
   Widget buildPostContent(String content) {
-    final cutoff = 100;
-    final shouldShowMore = content.length > cutoff;
+    final postCardContentLength = _getPostCardContentLength(content);
+    final shouldShowMore = postCardContentLength < content.length;
 
     return RichText(
       text: TextSpan(
@@ -35,7 +50,7 @@ class PostMiniCard extends StatelessWidget {
         ),
         children: <TextSpan>[
           TextSpan(
-            text: shouldShowMore ? content.substring(0, cutoff) : content,
+            text: content.substring(0, postCardContentLength),
           ),
           if (shouldShowMore)
             const TextSpan(
@@ -53,52 +68,51 @@ class PostMiniCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return InkWell(
-      onTap: () {
-        Get.to(PostPage(postId: id), arguments: 1);
-      },
-      child: Container(
-        width: SizeController.to.screenWidth,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(12),
-          color: AppColor.backgroundColor,
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(18.0),
-          child: Row(
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      title,
-                      style: const TextStyle(
-                          color: AppColor.textColor,
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16),
-                    ),
-                    buildPostContent(content),
-                    Text(
-                      DateFormat('yyyy년 M월 d일').add_jm().format(dateTime),
-                      style: const TextStyle(
-                        color: AppColor.textColor,
-                        fontWeight: FontWeight.normal,
-                        fontSize: 12,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              if (isPhoto)
-                SvgPicture.asset(
-                  'assets/images/base_image/base_post_image.svg',
-                  height: 64,
-                  width: 64,
-                )
-            ],
+        onTap: () {
+          Get.to(PostPage(postId: id), arguments: 1);
+        },
+        child: Container(
+          width: SizeController.to.screenWidth,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(12),
+            color: AppColor.backgroundColor,
           ),
-        ),
-      )
-    );
+          child: Padding(
+            padding: const EdgeInsets.all(18.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: const TextStyle(
+                            color: AppColor.textColor,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 16),
+                      ),
+                      buildPostContent(content),
+                      Text(
+                        DateFormat('yyyy년 M월 d일').add_jm().format(dateTime),
+                        style: const TextStyle(
+                          color: AppColor.textColor,
+                          fontWeight: FontWeight.normal,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                if (isPhoto)
+                  SvgPicture.asset(
+                    'assets/images/base_image/base_post_image.svg',
+                    height: 64,
+                    width: 64,
+                  )
+              ],
+            ),
+          ),
+        ));
   }
 }


### PR DESCRIPTION
### 게시글
- 게시글 및 댓글 레이아웃 조정
- 좋아요 색상 변경
- 게시글 리스트에서 좋아요 누를 수 있도록 변경
- 게시글 등록 후 자동으로 해당 게시글로 이동하도록 수정

### 댓글
- '답글 달기' 클릭시 해당 댓글 하이라이트 & 입력창 textholder '답글을 남겨보세요'로 변경
- 댓글 및 답글 등록 이후 해당 게시글에 바로 반영

### 내 활동 보기
- 내 활동 보기 > 내 게시글, 댓글 단 글, 좋아요한 글 구현
- 내 활동 보기에서 게시글 터치시 해당 게시글로 이동
- 내 활동 보기에서 긴 게시글 축약하여 노출
- 내 활동 보기에 스크롤하여 새로고침 기능 추가

### 게시판 관련 TODO 
- 댓글 수정이 구현 안된듯?
- 자동 새로고침 및 페이지 이동
  - 게시글 삭제 후 해당 게시글에 남아있음 + 뒤로가기 해서 리스트로 넘어와도 삭제된 게시글이 보임
  - 댓글 삭제시에도 갱신 필요(fetch만 다시 해주면 될듯)
  - 게시글 수정 이후 바텀시트도 그대로고 게시글도 그대로임(바텀시트는 Get.to 대신 Get.off 로 이동하면 해결될듯함)

**게시글, 댓글 삭제랑 수정 관련 이슈만 처리하면 이쪽은 완성일듯 합니다😀**