### PR TITLE
PR : 예약 시간 설정 화면 관련 이슈 (#102)

### DIFF
--- a/dplanner/lib/pages/club_timetable_page.dart
+++ b/dplanner/lib/pages/club_timetable_page.dart
@@ -2989,6 +2989,15 @@ class _ClubTimetablePageState extends State<ClubTimetablePage> {
                             Get.back();
                           } catch (e) {
                             print(e.toString());
+                            if (types == 0) {
+                              snackBar(
+                                  title: "예약 신청에 문제가 발생하였습니다",
+                                  content: "관리자에게 문의해주세요");
+                            } else {
+                              snackBar(
+                                  title: "예약 수정에 문제가 발생하였습니다",
+                                  content: "관리자에게 문의해주세요");
+                            }
                           }
                         }
                       },

--- a/dplanner/lib/pages/club_timetable_page.dart
+++ b/dplanner/lib/pages/club_timetable_page.dart
@@ -1134,6 +1134,34 @@ class _ClubTimetablePageState extends State<ClubTimetablePage> {
                                                 "시간을 변경하고 싶으시다면 새로 예약해주세요");
                                       } else {
                                         unableTime.clear();
+
+                                        // 일반 사용자의 경우 지난 시간 제외
+                                        if (!(MemberController.to
+                                                    .clubMember()
+                                                    .role ==
+                                                "ADMIN" ||
+                                            (MemberController.to
+                                                        .clubMember()
+                                                        .clubAuthorityTypes !=
+                                                    null &&
+                                                MemberController.to
+                                                    .clubMember()
+                                                    .clubAuthorityTypes!
+                                                    .contains(
+                                                        "SCHEDULE_ALL")))) {
+                                          if (reservationTime
+                                                  .isBefore(DateTime.now()) ||
+                                              reservationTime.day ==
+                                                  DateTime.now().day) {
+                                            for (var j = 0;
+                                                j <= DateTime.now().hour;
+                                                j++) {
+                                              unableTime.add(j);
+                                            }
+                                          }
+                                        }
+
+                                        // 기존 예약 시간 제외
                                         List<ReservationModel> reservations =
                                             await ReservationApiService.getReservations(
                                                 resourceId: selectedValue!.id,
@@ -1164,6 +1192,7 @@ class _ClubTimetablePageState extends State<ClubTimetablePage> {
                                           }
                                         }
 
+                                        // 기존 락 시간 제외
                                         List<LockModel> locks =
                                             await LockApiService.getLocks(
                                                 resourceId: selectedValue!.id,

--- a/dplanner/lib/pages/club_timetable_page.dart
+++ b/dplanner/lib/pages/club_timetable_page.dart
@@ -1154,6 +1154,10 @@ class _ClubTimetablePageState extends State<ClubTimetablePage> {
                                                 .substring(11, 13));
                                             int end = int.parse(i.endDateTime
                                                 .substring(11, 13));
+                                            if (end == 0) {
+                                              // 다음날 00으로 설정 되어 있을 경우 24로 설정
+                                              end = 24;
+                                            }
                                             for (var j = start; j < end; j++) {
                                               unableTime.add(j);
                                             }


### PR DESCRIPTION
### Summary
- 23~24 함께 있는 예약의 경우 시간 선택이 안 막혀 있는 에러 발견
- 시작 날 지난 시간대의 예약은 신청이 불가하게(일반 사용자 입장) 설정
- 예약 신청 및 수정 실패에 대한 안내 설정

### Description
- 다음날 00시를 24시로 설정
- 일반 사용자에 경우 지난 시간에 대한 예약 잠금
- 예약 신청 및 수정 실패했을 경우 관리자에게 문의하도록 안내문 전달