### PR TITLE
PR : 매니저 권한 관리 페이지 오류 수정 (#146)

### DIFF
--- a/dplanner/lib/pages/club_member_list_page.dart
+++ b/dplanner/lib/pages/club_member_list_page.dart
@@ -372,6 +372,17 @@ class _ClubMemberListPageState extends State<ClubMemberListPage> {
     String selectedValue = grade[0];
     List<ClubManagerModel> managers = [];
 
+    bool checkGradeChange() {
+      if (selectedValue == "관리자" && "ADMIN" == member.role) {
+        return false;
+      } else if (selectedValue == "일반" && "USER" == member.role) {
+        return false;
+      } else if (selectedValue == member.clubAuthorityName) {
+        return false;
+      }
+      return true;
+    }
+
     try {
       managers = await ClubManagerApiService.getClubManager(
           clubId: ClubController.to.club().id);
@@ -821,44 +832,48 @@ class _ClubMemberListPageState extends State<ClubMemberListPage> {
                       padding: const EdgeInsets.fromLTRB(24, 24, 24, 40),
                       child: NextPageButton(
                         text: const Text(
-                          "변경사항 반영하기",
+                          "변경 사항 반영하기",
                           style: TextStyle(
                               fontSize: 16,
                               fontWeight: FontWeight.w700,
                               color: AppColor.backgroundColor),
                         ),
-                        buttonColor: AppColor.objectColor,
+                        buttonColor: checkGradeChange()
+                            ? AppColor.objectColor
+                            : AppColor.subColor3,
                         onPressed: () async {
-                          String role = "";
-                          int? clubAuthorityId;
-                          if (selectedValue == "관리자") {
-                            role = "ADMIN";
-                          } else if (selectedValue == "일반") {
-                            role = "USER";
-                          } else {
-                            role = "MANAGER";
-                            for (var i in managers) {
-                              if (i.name == selectedValue) {
-                                clubAuthorityId = i.id;
+                          if (checkGradeChange()) {
+                            String role = "";
+                            int? clubAuthorityId;
+                            if (selectedValue == "관리자") {
+                              role = "ADMIN";
+                            } else if (selectedValue == "일반") {
+                              role = "USER";
+                            } else {
+                              role = "MANAGER";
+                              for (var i in managers) {
+                                if (i.name == selectedValue) {
+                                  clubAuthorityId = i.id;
+                                }
                               }
                             }
-                          }
-                          try {
-                            await ClubMemberApiService.patchAuthorities(
-                                clubMemberId: member.id,
-                                clubId: ClubController.to.club().id,
-                                role: role,
-                                clubAuthorityId: clubAuthorityId);
-                            getClubMemberList();
-                            Get.back();
-                            snackBar(
-                                title: "회원 등급을 변경했습니다",
-                                content: "회원 정보를 확인해주세요");
-                          } catch (e) {
-                            print(e.toString());
-                            snackBar(
-                                title: "회원 등급을 변경하지 못했습니다",
-                                content: "잠시 후 다시 시도해 주세요");
+                            try {
+                              await ClubMemberApiService.patchAuthorities(
+                                  clubMemberId: member.id,
+                                  clubId: ClubController.to.club().id,
+                                  role: role,
+                                  clubAuthorityId: clubAuthorityId);
+                              getClubMemberList();
+                              Get.back();
+                              snackBar(
+                                  title: "회원 등급을 변경했습니다",
+                                  content: "회원 정보를 확인해주세요");
+                            } catch (e) {
+                              print(e.toString());
+                              snackBar(
+                                  title: "회원 등급을 변경하지 못했습니다",
+                                  content: "잠시 후 다시 시도해 주세요");
+                            }
                           }
                         },
                       ),

--- a/dplanner/lib/pages/club_member_list_page.dart
+++ b/dplanner/lib/pages/club_member_list_page.dart
@@ -126,8 +126,14 @@ class _ClubMemberListPageState extends State<ClubMemberListPage> {
                       children: [
                         const BannerAdWidget(),
                         if (MemberController.to.clubMember().role == "ADMIN" ||
-                            (MemberController.to.clubMember().clubAuthorityTypes != null
-                                && MemberController.to.clubMember().clubAuthorityTypes!.contains("Member_ALL")))
+                            (MemberController.to
+                                        .clubMember()
+                                        .clubAuthorityTypes !=
+                                    null &&
+                                MemberController.to
+                                    .clubMember()
+                                    .clubAuthorityTypes!
+                                    .contains("Member_ALL")))
                           StreamBuilder<List<ClubMemberModel>>(
                               stream: streamController2.stream,
                               builder: (BuildContext context,
@@ -142,9 +148,15 @@ class _ClubMemberListPageState extends State<ClubMemberListPage> {
                                 } else if (snapshot.data!.isEmpty) {
                                   return const SizedBox();
                                 } else {
-                                  if (params.containsKey("clubMemberId") && params["clubMemberId"] != null) {
-                                    int clubMemberId = int.parse(params["clubMemberId"]!);
-                                    _clubMemberInfo(types: 0, member: snapshot.data!.firstWhere((member) => member.id == clubMemberId));
+                                  if (params.containsKey("clubMemberId") &&
+                                      params["clubMemberId"] != null) {
+                                    int clubMemberId =
+                                        int.parse(params["clubMemberId"]!);
+                                    _clubMemberInfo(
+                                        types: 0,
+                                        member: snapshot.data!.firstWhere(
+                                            (member) =>
+                                                member.id == clubMemberId));
                                     Get.parameters.clear();
                                   }
 
@@ -309,9 +321,17 @@ class _ClubMemberListPageState extends State<ClubMemberListPage> {
                           size: 20,
                         ),
                       ),
-                    if ((MemberController.to.clubMember().role == "ADMIN" || (MemberController.to.clubMember().clubAuthorityTypes != null && MemberController.to.clubMember().clubAuthorityTypes!.contains("MEMBER_ALL")))
-                        && member.role != "ADMIN"
-                        && member.id != MemberController.to.clubMember().id)
+                    if ((MemberController.to.clubMember().role == "ADMIN" ||
+                            (MemberController.to
+                                        .clubMember()
+                                        .clubAuthorityTypes !=
+                                    null &&
+                                MemberController.to
+                                    .clubMember()
+                                    .clubAuthorityTypes!
+                                    .contains("MEMBER_ALL"))) &&
+                        member.role != "ADMIN" &&
+                        member.id != MemberController.to.clubMember().id)
                       Visibility(
                         visible: member.isConfirmed,
                         replacement: IconButton(
@@ -348,7 +368,7 @@ class _ClubMemberListPageState extends State<ClubMemberListPage> {
   //types: 0-승인 대기중, 1-회원 정보, 2-등급 수정
   Future<void> _clubMemberInfo(
       {required int types, required ClubMemberModel member}) async {
-    List<String> grade = ['일반', '관리자'];
+    List<String> grade = ['관리자'];
     String selectedValue = grade[0];
     List<ClubManagerModel> managers = [];
 
@@ -356,10 +376,14 @@ class _ClubMemberListPageState extends State<ClubMemberListPage> {
       managers = await ClubManagerApiService.getClubManager(
           clubId: ClubController.to.club().id);
       for (var i in managers) {
-        grade.insert(0, i.name);
+        grade.insert(grade.length, i.name);
       }
-      selectedValue =
-          (member.role == "MANAGER") ? member.clubAuthorityName ?? "" : "일반";
+      grade.insert(grade.length, '일반');
+      selectedValue = (member.role == "ADMIN")
+          ? "관리자"
+          : (member.role == "MANAGER")
+              ? member.clubAuthorityName ?? ""
+              : "일반";
     } catch (e) {
       print(e.toString());
     }
@@ -724,7 +748,13 @@ class _ClubMemberListPageState extends State<ClubMemberListPage> {
                   ),
                 ),
               ),
-              if (member.id != MemberController.to.clubMember().id)
+              if (member.id != MemberController.to.clubMember().id ||
+                  (MemberController.to.clubMember().clubAuthorityTypes !=
+                          null &&
+                      MemberController.to
+                          .clubMember()
+                          .clubAuthorityTypes!
+                          .contains("MEMBER_ALL")))
                 Visibility(
                   visible: types != 0,
                   replacement: Padding(
@@ -821,10 +851,14 @@ class _ClubMemberListPageState extends State<ClubMemberListPage> {
                                 clubAuthorityId: clubAuthorityId);
                             getClubMemberList();
                             Get.back();
-                            snackBar(title: "회원 등급을 변경했습니다", content: "회원 정보를 확인해주세요");
+                            snackBar(
+                                title: "회원 등급을 변경했습니다",
+                                content: "회원 정보를 확인해주세요");
                           } catch (e) {
                             print(e.toString());
-                            snackBar(title: "회원 등급을 변경하지 못했습니다", content: "잠시 후 다시 시도해 주세요");
+                            snackBar(
+                                title: "회원 등급을 변경하지 못했습니다",
+                                content: "잠시 후 다시 시도해 주세요");
                           }
                         },
                       ),


### PR DESCRIPTION
### Summary
- 일반 사용자가 등급 권한 바꾸는거 차단
- 등급 변경 시에만 클릭되게 변경

### Description
- 멤버 관리 권한 가진 사람만 사용자 등급 변경할 수 있도록 설정
- 등급 변경 시에만 색깔이 바뀌며 버튼이 클릭되게 반영함